### PR TITLE
Поправить перекрытие меню элементом __stub

### DIFF
--- a/src/components/Settings/SettingsPage/settings-page.scss
+++ b/src/components/Settings/SettingsPage/settings-page.scss
@@ -103,13 +103,17 @@ $namespace: '.settings-page';
   &__stub {
     position: absolute;
     top: 50%;
-    left: 0;
+    left: 300px;
     right: 0;
     display: flex;
     flex-direction: column;
     align-items: center;
     color: $fontGrey;
     transform: translateY(-50%);
+
+    @include media('mobile') {
+      left: 0;
+    }
 
     h2, h5 {
       margin-bottom: 0;


### PR DESCRIPTION
Элемент __stub перекрывал левое меню в настройках. Поправил.