### PR TITLE
Сортировка в Ключевых словах, через изменение position

### DIFF
--- a/src/components/Project/ProjectCreatePage/ProjectKeyWords/ProjectKeyWords.jsx
+++ b/src/components/Project/ProjectCreatePage/ProjectKeyWords/ProjectKeyWords.jsx
@@ -278,7 +278,6 @@ export default class ProjectKeyWords extends Component {
                 </section>
 
                 <Virtuoso 
-                    style={{ height: '500px' }}
                     totalCount={keyWords.length}
                     item={this.renderItem}
                     endReached={this.handleEndReached}

--- a/src/components/Project/ProjectCreatePage/ProjectKeyWords/project-key-words.scss
+++ b/src/components/Project/ProjectCreatePage/ProjectKeyWords/project-key-words.scss
@@ -8,7 +8,7 @@ $namespace: '.project-key-words';
   flex-direction: column;
   height: 100%;
   padding-top: 40px;
-  padding-bottom: 40px;
+  padding-bottom: 0;
   z-index: 1;
 
   &__list {
@@ -54,6 +54,14 @@ $namespace: '.project-key-words';
     fill: #b2b2b2;
     color: #b2b2b2;
     overflow: hidden;
+
+    &--arrow-to-start {
+      transform: rotate(-90deg);
+    }
+
+    &--arrow-to-end {
+      transform: rotate(90deg);
+    }
   }
 
   &__buttons-panel {


### PR DESCRIPTION
Сортировка в Ключевых словах, через изменение position

- Перетаскивание drag&drop. Источником истины выступает бэкенд, при переносе проверяется позиция следующего элемента, а переносимый элемент получает его позицию. Это позволяет переносить на актуальную позицию, но не обновлять весь список с сервера, так как это бы вызвало проблему с пагинацией. Если следующего элемента нет (перенесено в конец), передаётся `position: -1`.
- drag&drop и пагинация не мешают друг-другу. Можно нести элемент, список будет подгружаться. 
- Перенос в начало списка. Перемещается в состоянии фронта в начало массива, обновляется позиция на сервере. Список с сервера заново не запрашивается.
- Перенос в конец списка:
— Если не достигнут конец пагинации, то обновляется позиция на сервере, а весь список запрашивается с сервера заново. Так как перенесено в конец, нужное слово мы просто увидим на последней пагинации.
— Если достигнут конец пагинации, то в состоянии фронта переносится в конец массива, обновляется позиция, а список с сервера при этом заново не запрашивается.