### PR TITLE
На TopBarButton исправить клик по SVG графике

### DIFF
--- a/src/components/Shared/TopBar/TopBarButton/index.js
+++ b/src/components/Shared/TopBar/TopBarButton/index.js
@@ -36,7 +36,8 @@ export default function TopBarButton({
                 if (
                     withList && (
                         event.target.classList.contains(namespace) ||
-                        event.target.classList.contains(`${namespace}__icon`)
+                        event.target.classList.contains(`${namespace}__icon`) ||
+                        event.target.viewportElement?.tagName === 'svg'
                     )
                 ) {
                     setIsOpen(!isOpen);


### PR DESCRIPTION
Исправлен баг на компоненте TopBarButton. Не срабатывала кнопка при попадании на элементы SVG графики в иконке кнопки.