### PR TITLE
MECCANO-242

### DIFF
--- a/src/components/Article/ArticleCeratePage/ArticleCreatePage.jsx
+++ b/src/components/Article/ArticleCeratePage/ArticleCreatePage.jsx
@@ -96,7 +96,9 @@ class ArticleCreatePage extends Component {
             timeZone: defaultTimeZone,
             inProgress: true,
             loadedSources: [],
-            loadedCities: []
+            loadedCities: [],
+            sectionsTwo: [],
+            sectionsThree: []
         };
     }
 
@@ -753,7 +755,6 @@ class ArticleCreatePage extends Component {
                 break;
             case 'section_three_id':
                 field.options = sectionsThree.map(({ name, id }) => ({ label: name, value: id }));
-                field.isHidden = !sectionsThree.length || false;
                 break;
             case 'genre_id':
                 field.requestService = ArticleService.genre;

--- a/src/components/Article/ArticleCeratePage/ArticleCreatePage.jsx
+++ b/src/components/Article/ArticleCeratePage/ArticleCreatePage.jsx
@@ -755,6 +755,7 @@ class ArticleCreatePage extends Component {
                 break;
             case 'section_three_id':
                 field.options = sectionsThree.map(({ name, id }) => ({ label: name, value: id }));
+                field.isHidden = !sectionsThree.length || false;
                 break;
             case 'genre_id':
                 field.requestService = ArticleService.genre;

--- a/src/components/Article/ArticleCeratePage/ArticleCreatePage.jsx
+++ b/src/components/Article/ArticleCeratePage/ArticleCreatePage.jsx
@@ -582,20 +582,12 @@ class ArticleCreatePage extends Component {
     };
 
     getDataSectionFields = () => {
-        const { form, sectionsTwo, sectionsThree, projectFields } = this.state;
+        const { projectFields } = this.state;
         const clonedFields = projectFields && projectFields.length ? _.cloneDeep(projectFields) : [];
 
-        let dataSectionFields = clonedFields.filter(({ slug }) => {
+        const dataSectionFields = clonedFields.filter(({ slug }) => {
             return !this.unSortableFields.includes(slug);
         });
-
-        if (!form.section_main_id || !sectionsTwo || !sectionsTwo.length) {
-            dataSectionFields = dataSectionFields.filter(({ slug }) => slug !== 'section_sub_id');
-        }
-
-        if (!form.section_sub_id || !sectionsThree || !sectionsThree.length) {
-            dataSectionFields = dataSectionFields.filter(({ slug }) => slug !== 'section_three_id');
-        }
 
         return dataSectionFields
             .filter(({ slug }) => slug !== 'user_id')
@@ -642,7 +634,7 @@ class ArticleCreatePage extends Component {
 
     saveFieldsSort = () => {
         const { projectFields, userTypeId, roles } = this.state;
-        const readOnly = !isProjectAccess([ PROJECT_PERMISSION.EDIT ]) && !isRolesAccess(roles.admin);
+        const readOnly = !isProjectAccess([ PROJECT_PERMISSION.EDIT ]) && !isRolesAccess(roles?.admin);
 
         if (readOnly) return;
 
@@ -729,7 +721,7 @@ class ArticleCreatePage extends Component {
         const { form, sections, sectionsTwo, sectionsThree } = this.state;
         const getValue = (prop) => _.isObject(prop) ? prop.value : prop;
 
-        field.readOnly = !isProjectAccess([ PROJECT_PERMISSION.EDIT ]) && !isRolesAccess(roles.admin);
+        field.readOnly = !isProjectAccess([ PROJECT_PERMISSION.EDIT ]) && !isRolesAccess(roles?.admin);
 
         switch (field.slug) {
             case 'source_id':
@@ -757,9 +749,11 @@ class ArticleCreatePage extends Component {
                     value: section.id,
                     sectionsThree: section.sectionsThree
                 }));
+                field.isHidden = !sectionsTwo.length || false;
                 break;
             case 'section_three_id':
                 field.options = sectionsThree.map(({ name, id }) => ({ label: name, value: id }));
+                field.isHidden = !sectionsThree.length || false;
                 break;
             case 'genre_id':
                 field.requestService = ArticleService.genre;
@@ -829,6 +823,7 @@ class ArticleCreatePage extends Component {
                 placeholder={field.name}
                 value={form[field.slug] || ''}
                 onChange={this.handleChangeForm}
+                isHidden={field?.isHidden}
             />
         );
     };
@@ -847,7 +842,7 @@ class ArticleCreatePage extends Component {
         } = this.state;
         const isUpdate = !!this.state.articleId;
         const dataSectionFields = this.getDataSectionFields();
-        const readOnly = !isProjectAccess([ PROJECT_PERMISSION.EDIT ]) && !isRolesAccess(roles.admin);
+        const readOnly = !isProjectAccess([ PROJECT_PERMISSION.EDIT ]) && !isRolesAccess(roles?.admin);
         const annotationField = projectFields.find(({ slug }) => slug === 'annotation');
         const textField = projectFields.find(({ slug }) => slug === 'text');
         const sectionData = (
@@ -1080,7 +1075,7 @@ class ArticleCreatePage extends Component {
 
 function mapStateToProps(state) {
     const roles = {};
-
+    
     state.roles.forEach(({ name }) => roles[name] = name);
 
     return {

--- a/src/components/Project/ProjectCreatePage/ProjectCreatePageField/ProjectCreatePageField.jsx
+++ b/src/components/Project/ProjectCreatePage/ProjectCreatePageField/ProjectCreatePageField.jsx
@@ -12,8 +12,10 @@ import AsyncCreatableSelect from "../../../Form/AsyncCreatebleSelect/AsyncCreate
 import Select from '../../../Form/Select/ReactSelect/ReactSelect';
 
 const cls = new Bem('article-create-page');
-const ProjectCreateField = ({field, value, onChange, className}) => {
+const ProjectCreateField = ({field, value, onChange, className, isHidden}) => {
     const filedType = field.type.key;
+
+    if (isHidden) return <div {...cls('hidden-field')} data-id={field.slug} />;
 
     switch (filedType) {
         case FIELD_TYPE.ARRAY:


### PR DESCRIPTION
Вместо удаления поля Раздела, происходит его замещение заглушкой с нужным `data-id` атрибутом, в результате оно не выпадает из сортировки.

Проблема заключалась в том, что компонент <Sortable /> на onChange возвращает список сортированных полей, основываясь на артибуте `data-id` у элементов. В результате `slug` поля не попадал в массив на обновление полей проекта. А так как видимость полей и сортировка включены в единную сущность на проекте, невернувшееся на onChange поле отваливалось от проекта.

Также была проблема, если нет прав на изменение статьи, сортировка полей вызывала падение всего приложения. Пофиксил это оператором `?`.